### PR TITLE
updated calendly widget link and the link in standardPackageData.json…

### DIFF
--- a/src/components/Calendly.js
+++ b/src/components/Calendly.js
@@ -16,7 +16,7 @@ const Calendly = () => {
     <div>
       <div
         className="calendly-inline-widget"
-        data-url="https://calendly.com/teamcarambatesting/1-2-1-tutoring-session-free-trial-parents"
+        data-url="https://calendly.com/teamcarambatesting/1-2-1-tutoring-session-free-trial-edition"
         style={{ minWidth: "320px", width: "100%", height: "630px" }}
       ></div>
     </div>

--- a/src/data/standardPackageData.json
+++ b/src/data/standardPackageData.json
@@ -5,7 +5,7 @@
     "description": "Short and sweet - book your free 30-minute trial and start speaking French like the French. Salutations!",
     "rate": "Free",
     "btnMsg": "Book Now",
-    "link": "https://calendly.com/teamcarambatesting/1-2-1-tutoring-session-free-trial",
+    "link": "https://calendly.com/teamcarambatesting/1-2-1-tutoring-session-free-trial-edition",
     "bestValue": false
   },
   { "id": 2,


### PR DESCRIPTION
… to link through to correct calendly booking form, free-trial-edition